### PR TITLE
Fixed #9153 - Adding dynamicenum case option for export

### DIFF
--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -300,7 +300,9 @@ function export($type, $records = null, $members = false, $sample=false)
             $value = implode(",", $valueArray);
 
                         break;
-
+                            
+        // Fix Issue 9153 - Exporting DynamicDropdown fields return keys
+        case 'dynamicenum':
         case 'enum':
             if (isset($focus->field_name_map[$fields_array[$key]]['options']) &&
                 isset($app_list_strings[$focus->field_name_map[$fields_array[$key]]['options']]) &&


### PR DESCRIPTION
Closes: https://github.com/salesagility/SuiteCRM/issues/9153

When exporting a record for any module that contains a DynamicDropdown field, the content isn't exported properly.

## Description

When using the function export of a record of any module that contains a DynamicDropdown field, it exports the keys of the field, instead of the label assigned to that key.

## Motivation and Context
I feel this is an important functionality for any user working with export.

## How To Test This
1. Add a dynamicdropdown field in a EditView of any module
2. Create a record in that module filling the DynamicDropdown field
3. Export that record and see that the value of the field isn't the expected one

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.