### PR TITLE
Fix #9449 - Password is automatically added in the "Old password" input of the User profile

### DIFF
--- a/modules/Users/tpls/EditViewFooter.tpl
+++ b/modules/Users/tpls/EditViewFooter.tpl
@@ -112,7 +112,7 @@
                                     </td>
                                     <td>
                                         <input name='old_password' id='old_password' type='password' tabindex='2'
-                                               onkeyup="password_confirmation();">
+                                               onkeyup="password_confirmation();" autocomplete='new-password'>
                                     </td>
                                     <td width='40%'>
                                     </td>


### PR DESCRIPTION
Closes #9449

## Description
As described in the Issue, the old_password of the profile EditView is automatically filled when the credentials are saved in the browser.

In this PR we add the option "autocomplete='new-password'" to the input element of the old_password, pointing any browser that the field shouldn't be filled. More info about the property here: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields

## Motivation and Context
This change will avoid filling the old_password automatically when the user want to change/save other options.

## How To Test This
1. Save the authentication credentials in the browser
2. Open the profile user page
3. Check that the old_password isn't filled automatically

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.